### PR TITLE
Explicitly mark the failure policy as fail

### DIFF
--- a/cmd/chimera/server.go
+++ b/cmd/chimera/server.go
@@ -66,9 +66,12 @@ func startServer(c *cli.Context) error {
 						},
 					},
 				},
-				Callback:      processRequest,
-				Path:          validatePath,
-				FailurePolicy: admissionregistrationv1.Ignore,
+				Callback: processRequest,
+				Path:     validatePath,
+				// Despite it is the default in the apiserver when registering if
+				// missing, make it explicit that the failure policy is fail -- if
+				// the webhook cannot be contacted, the request will be rejected
+				FailurePolicy: admissionregistrationv1.Fail,
 			},
 		},
 		TLSExtraSANs: tlsExtraSANs.Value(),


### PR DESCRIPTION
If the webhook cannot be contacted by the apiserver, let it reject the
request because we don't know if this request would have been accepted
by the webhook. The safest option is to reject everything that cannot
be verified.