### PR TITLE
Make FailurePolicy configurable

### DIFF
--- a/cmd/chimera/app.go
+++ b/cmd/chimera/app.go
@@ -32,6 +32,7 @@ var (
 	keyFile                   string
 	caFile                    string
 	insecureServer            bool
+	failurePolicy             string
 
 	wasmWorker *chimera.WasmWorker
 )
@@ -72,6 +73,13 @@ func NewApp() *cli.App {
 				Value:       8443,
 				EnvVars:     []string{"CHIMERA_CALLBACK_PORT"},
 				Destination: &admissionPort,
+			},
+			&cli.StringFlag{
+				Name:        "failure-policy",
+				Value:       "Ignore",
+				Usage:       "Admission controller failure policy, allowed values are Ignored (request is allowed to continue if webhook cannot be reached) or Fail (request is rejected if webhook cannot be reached), defaults to Ignore",
+				EnvVars:     []string{"CHIMERA_FAILURE_POLICY"},
+				Destination: &failurePolicy,
 			},
 			&cli.StringFlag{
 				Name:        "kube-namespace",

--- a/cmd/chimera/server.go
+++ b/cmd/chimera/server.go
@@ -19,6 +19,10 @@ func startServer(c *cli.Context) error {
 		return errors.New("Please, provide a Wasm URI to load")
 	}
 
+	if fp := strings.ToLower(failurePolicy); fp != "ignore" && fp != "fail" {
+		return errors.New("FailurePolicy must be \"Ignore\" or \"Fail\"")
+	}
+
 	var wasmModulePath string
 
 	moduleSource, modulePath, err := chimera.WasmModuleSource(wasmUri)
@@ -103,7 +107,7 @@ func startServer(c *cli.Context) error {
 				},
 				Callback:      processRequest,
 				Path:          validatePath,
-				FailurePolicy: admissionregistrationv1.Ignore,
+				FailurePolicy: admissionregistrationv1.FailurePolicyType(failurePolicy),
 			},
 		},
 		TLSExtraSANs:              tlsExtraSANs.Value(),


### PR DESCRIPTION
Add a new flag and environment variable to make the webhook
FailurePolicy configurable.

Fixes #2 